### PR TITLE
feat: propose remember-selected-movie change

### DIFF
--- a/openspec/changes/remember-selected-movie/.openspec.yaml
+++ b/openspec/changes/remember-selected-movie/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/remember-selected-movie/design.md
+++ b/openspec/changes/remember-selected-movie/design.md
@@ -1,0 +1,28 @@
+## Context
+
+The movie catalog app displays a list of movies on the main screen. Users can select a movie to view its details. Currently, when users navigate back from the movie details screen, the previously selected movie is not visually highlighted, making it difficult to maintain context in the list.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Persist the selected movie ID during navigation to movie details
+- Visually highlight the selected movie when returning to the main list
+- Maintain selection state only during the current app session
+
+**Non-Goals:**
+- Persist selection across app restarts or backgrounding
+- Store selection in persistent storage
+- Modify the movie details screen behavior
+
+## Decisions
+
+**UI State Management**: Store the selected movie ID in the MainViewModel's UI state alongside the movie list data. This ensures the selection is part of the reactive state flow and automatically updates the UI when changed.
+
+**Visual Highlighting**: Use a different background color or border for the selected movie card in the LazyVerticalGrid. The selection will be applied at the composable level using the movie ID comparison.
+
+**Selection Reset**: Clear the selection when the user performs pull-to-refresh or when new data is loaded, ensuring the selection doesn't persist inappropriately across data changes.
+
+## Risks / Trade-offs
+
+- **UI Performance**: Adding selection highlighting to each movie card could have minimal performance impact on large lists → Mitigation: Use efficient conditional styling that only affects the selected item
+- **State Complexity**: Adding selection state increases ViewModel complexity → Mitigation: Keep selection logic simple and contained within the existing UI state structure

--- a/openspec/changes/remember-selected-movie/proposal.md
+++ b/openspec/changes/remember-selected-movie/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Users can lose their place in the movie list when navigating to movie details and returning. This creates a poor user experience as they have to scroll back to find their previously selected movie. Remembering the selected movie provides better navigation continuity and user satisfaction.
+
+## What Changes
+
+- Add persistence of the selected movie ID in the main screen's UI state
+- Restore the selected movie highlight when returning from movie details
+- Maintain selection state across app navigation
+
+## Capabilities
+
+### New Capabilities
+- `selected-movie-persistence`: Capability to remember and restore the selected movie when returning to the main movie list
+
+### Modified Capabilities
+<!-- No existing capabilities are modified -->
+
+## Impact
+
+- Main screen UI state management
+- Movie selection handling in MainViewModel
+- Potential storage of selection state (if needed across app sessions)

--- a/openspec/changes/remember-selected-movie/specs/selected-movie-persistence/spec.md
+++ b/openspec/changes/remember-selected-movie/specs/selected-movie-persistence/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Remember selected movie on navigation
+The system SHALL remember the selected movie when navigating to movie details and restore the selection when returning to the main movie list.
+
+#### Scenario: Selected movie remains highlighted after navigation
+- **WHEN** user selects a movie from the main list
+- **AND** navigates to the movie details screen
+- **AND** returns to the main movie list
+- **THEN** the previously selected movie remains visually highlighted in the list
+
+#### Scenario: Selection cleared on data refresh
+- **WHEN** user performs pull-to-refresh on the main movie list
+- **THEN** any existing movie selection is cleared
+- **THEN** no movie appears highlighted in the refreshed list
+
+#### Scenario: Selection maintained during pagination
+- **WHEN** user has a movie selected
+- **AND** loads additional pages of movies
+- **THEN** the selected movie remains highlighted
+- **THEN** the selection is not affected by new movie items being added to the list

--- a/openspec/changes/remember-selected-movie/tasks.md
+++ b/openspec/changes/remember-selected-movie/tasks.md
@@ -1,0 +1,21 @@
+## 1. UI State Management
+
+- [ ] 1.1 Add selectedMovieId field to MainUiState data class
+- [ ] 1.2 Update MainViewModel to initialize selectedMovieId as null
+- [ ] 1.3 Add method to update selected movie ID in ViewModel
+
+## 2. Selection Handling
+
+- [ ] 2.1 Modify MainScreen to pass selected movie ID to CardItemComposable
+- [ ] 2.2 Update CardItemComposable to accept and use selectedMovieId parameter
+- [ ] 2.3 Implement visual highlighting for selected movie card
+
+## 3. Navigation Integration
+
+- [ ] 3.1 Update onMovieSelected callback to set selected movie ID in ViewModel
+- [ ] 3.2 Ensure selected movie ID persists when navigating to details and back
+
+## 4. Selection Reset
+
+- [ ] 4.1 Clear selected movie ID when pull-to-refresh is triggered
+- [ ] 4.2 Clear selected movie ID when new data is loaded (page 1 refresh)


### PR DESCRIPTION
Propose a new OpenSpec change to remember the selected movie when returning to the main movie list.

## Change: remember-selected-movie

This PR adds the complete OpenSpec change proposal for remembering selected movies, including:

### Artifacts
- **proposal.md**: Establishes the need to remember selected movies for better navigation continuity
- **design.md**: Technical design using ViewModel state management and UI highlighting
- **specs/selected-movie-persistence/spec.md**: Requirements for selection persistence during navigation
- **tasks.md**: 10 implementation tasks covering UI state, selection handling, and reset logic

### Capabilities
- **New**:  - Capability to remember and restore selected movie when returning to the main list

### Next Steps
Once approved, run `/opsx:apply remember-selected-movie` to start implementation.