### PR TITLE
Propose: Restore list scroll position on navigation

### DIFF
--- a/openspec/changes/restore-list-scroll-position/.openspec.yaml
+++ b/openspec/changes/restore-list-scroll-position/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/restore-list-scroll-position/design.md
+++ b/openspec/changes/restore-list-scroll-position/design.md
@@ -65,8 +65,13 @@ The app uses Android Navigation Component for screen transitions and Jetpack Vie
 5. Test back navigation, configuration changes, and edge cases
 6. No database migration or backwards compatibility concerns
 
-## Open Questions
+## Open Questions and Decisions
 
-- Should scroll position be cleared when user manually refreshes the list (pull-to-refresh)?
-- Should this feature be configurable/toggleable by the user?
-- Do we need to restore offset or only item index?
+- **Should scroll position be cleared when user manually refreshes the list (pull-to-refresh)?**
+  - Yes. Pull-to-refresh indicates the user expects a refreshed list state, so stored scroll position should be cleared to avoid restoring outdated context.
+
+- **Should this feature be configurable/toggleable by the user?**
+  - No. This is a UX quality improvement that should be standard behavior and does not require a user-facing toggle.
+
+- **Do we need to restore offset or only item index?**
+  - Restore both item index and offset. Preserving the exact position improves the visual continuity when returning to the list.

--- a/openspec/changes/restore-list-scroll-position/design.md
+++ b/openspec/changes/restore-list-scroll-position/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The movie list component uses RecyclerView to display paginated results. When users navigate to the movie details page and return, the RecyclerView resets to position 0, losing the user's place in the list. This was introduced after adding the remember-selected-movie feature but the scroll state preservation was not implemented alongside it.
+
+The app uses Android Navigation Component for screen transitions and Jetpack ViewModel for state management across configuration changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Capture and persist the RecyclerView scroll position (first visible item index) when navigating away from the list
+- Restore the exact scroll position when returning to the list screen
+- Ensure the previously selected movie remains highlighted after scroll restoration
+- Handle both smooth back navigation and recomposition due to configuration changes
+
+**Non-Goals:**
+- Changing how the selected movie is remembered (separate feature)
+- Modifying pagination or data loading behavior
+- Altering the navigation architecture
+
+## Decisions
+
+**1. Store scroll state in a dedicated ViewModel property**
+- *Choice*: Use a ViewModel LiveData or StateFlow to hold `(firstVisibleItemIndex, firstVisibleItemOffset)`
+- *Rationale*: Survives configuration changes and activity recreation; survives back navigation on the same NavGraph
+- *Alternative considered*: SavedInstanceState only - insufficient for back navigation; Bundle arguments - loses state on config change
+
+**2. Capture scroll position before navigation**
+- *Choice*: Add a RecyclerView.OnScrollListener to capture position when user scrolls; also capture just before calling navigate()
+- *Rationale*: Ensures position is saved before navigation event fires; prevents data race
+- *Alternative considered*: Capture only on pause - misses rapid clicks; capture in onPause() only - timing issues with async transitions
+
+**3. Restore scroll position after data load**
+- *Choice*: Restore in RecyclerAdapter.onBindViewHolder or after observing list updates
+- *Rationale*: Ensures RecyclerView is laid out and data is populated before restoring position
+- *Alternative considered*: Restore immediately in onViewCreated - RecyclerView may not be laid out yet
+
+**4. Handle edge cases**
+- *Choice*: If saved position exceeds new list size, clamp to (size - 1); if list is empty, skip restoration
+- *Rationale*: Prevents IndexOutOfBoundsException; handles pagination/filtering scenarios
+
+## Risks / Trade-offs
+
+**[Risk] Stale scroll position after data refresh**
+- Occurs if list data changes significantly (filters, sorting, new data)
+- *Mitigation*: Clear stored position when user changes filters or sorts; add flag to detect data-affecting operations
+
+**[Risk] Restoration timing - scroll before layout complete**
+- Calling scrollToPosition before RecyclerView layout pass may be ignored
+- *Mitigation*: Use post() or ViewTreeObserver.OnPreDrawListener to delay restoration until after layout
+
+**[Risk] Performance impact if list is very large**
+- Restoring to a far position in a 10k-item list takes time
+- *Mitigation*: Acceptable trade-off for UX; measure and optimize if profiling shows issues
+
+**[Risk] Memory overhead**
+- Storing scroll position adds minimal memory (two integers per list screen)
+- *Mitigation*: Negligible; clear when screen is destroyed
+
+## Migration Plan
+
+1. Add scroll position properties to existing MovieListViewModel
+2. Add RecyclerView scroll listener in MovieListFragment to capture position
+3. Intercept navigation events to save position before navigating away
+4. Restore position after data load (in data observer callback)
+5. Test back navigation, configuration changes, and edge cases
+6. No database migration or backwards compatibility concerns
+
+## Open Questions
+
+- Should scroll position be cleared when user manually refreshes the list (pull-to-refresh)?
+- Should this feature be configurable/toggleable by the user?
+- Do we need to restore offset or only item index?

--- a/openspec/changes/restore-list-scroll-position/proposal.md
+++ b/openspec/changes/restore-list-scroll-position/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+After introducing the remember-selected-movie feature, users navigate back to the movie list from the details page only to find the list scrolled to the top. This breaks the user experience where the previously viewed movie should remain visible and highlighted in the list.
+
+## What Changes
+
+- Capture the current scroll position in the list when navigating away to details
+- Restore the exact scroll position when returning from details
+- Ensure the previously selected movie item is highlighted during scroll restoration
+- Maintain scroll state across navigation back/forward cycles
+
+## Capabilities
+
+### New Capabilities
+- `list-scroll-position`: Restores and maintains the movie list's scroll position when navigating between list and details screens
+
+### Modified Capabilities
+<!-- Existing capabilities whose REQUIREMENTS are changing (not just implementation).
+     Only list here if spec-level behavior changes. Each needs a delta spec file.
+     Use existing spec names from openspec/specs/. Leave empty if no requirement changes. -->
+
+## Impact
+
+- Movie list UI component (scroll state management)
+- Navigation lifecycle (state preservation during transitions)
+- Integration with existing selected-movie-persistence feature

--- a/openspec/changes/restore-list-scroll-position/specs/list-scroll-position/spec.md
+++ b/openspec/changes/restore-list-scroll-position/specs/list-scroll-position/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Capture scroll position on navigation away
+The system SHALL capture the current scroll position (first visible item index and offset) of the movie list whenever the user navigates away from the list screen.
+
+#### Scenario: User scrolls list then navigates to details
+- **WHEN** user scrolls the movie list to position 25 and clicks on a movie to view details
+- **THEN** the system captures and stores scroll position (25, offset) in memory
+
+#### Scenario: User scrolls list then uses back gesture
+- **WHEN** user scrolls the movie list to position 15 and uses Android back button
+- **THEN** the system captures and stores scroll position (15, offset) before the back navigation executes
+
+### Requirement: Persist scroll position across navigation
+The system SHALL maintain the stored scroll position in ViewModel state to survive configuration changes and back navigation on the same navigation graph.
+
+#### Scenario: Configuration change during details view
+- **WHEN** user navigates to details screen, then device orientation changes
+- **THEN** the scroll position captured from the list is preserved and available when returning to list
+
+#### Scenario: Back navigation from details
+- **WHEN** user navigates from details back to list screen
+- **THEN** the previously captured scroll position is still available and not cleared
+
+### Requirement: Restore scroll position when returning to list
+The system SHALL restore the movie list to the previously captured scroll position when the user returns to the list screen after navigating away.
+
+#### Scenario: Return from details to list
+- **WHEN** user navigates back from movie details to the list screen
+- **THEN** the list scrolls to the previously captured position
+
+#### Scenario: Scroll restoration timing
+- **WHEN** user returns to list and the RecyclerView completes layout
+- **THEN** the system applies the scroll restoration (does not restore before layout is complete)
+
+### Requirement: Handle edge cases in scroll restoration
+The system SHALL gracefully handle scenarios where the saved scroll position is no longer valid or applicable.
+
+#### Scenario: Saved position exceeds current list size
+- **WHEN** user returns to list and the saved position index exceeds the current list size
+- **THEN** the system clamps the position to (list.size - 1)
+
+#### Scenario: List is empty on return
+- **WHEN** user returns to list and the list has no items
+- **THEN** the system does not attempt scroll restoration
+
+#### Scenario: First time visiting list
+- **WHEN** user opens the app for the first time and views the list
+- **THEN** the list displays normally at the top; no scroll restoration is attempted
+
+### Requirement: Clear scroll position on relevant list changes
+The system SHALL clear the stored scroll position when the user performs actions that significantly change the list contents.
+
+#### Scenario: User applies new filter
+- **WHEN** user applies a filter that changes the list results
+- **THEN** the stored scroll position is cleared
+
+#### Scenario: User sorts list differently
+- **WHEN** user changes the sort order of the list
+- **THEN** the stored scroll position is cleared
+
+#### Scenario: User manually refreshes list
+- **WHEN** user performs a pull-to-refresh gesture on the list
+- **THEN** the stored scroll position is cleared
+
+### Requirement: Maintain highlight on selected movie
+The system SHALL ensure the previously selected movie (from remember-selected-movie feature) remains highlighted after scroll restoration.
+
+#### Scenario: Highlight persists after scroll restoration
+- **WHEN** list is restored to saved scroll position
+- **THEN** the previously selected movie maintains its highlight state
+
+#### Scenario: Selected movie is visible in restored position
+- **WHEN** previously selected movie is within the scroll range of the restored position
+- **THEN** user can see the selected movie highlighted without additional scrolling

--- a/openspec/changes/restore-list-scroll-position/tasks.md
+++ b/openspec/changes/restore-list-scroll-position/tasks.md
@@ -1,0 +1,70 @@
+## 1. Update MovieListViewModel
+
+- [ ] 1.1 Add LiveData/StateFlow properties to hold scroll position (firstVisibleItemIndex, firstVisibleItemOffset)
+- [ ] 1.2 Add method to save scroll position
+- [ ] 1.3 Add method to get stored scroll position
+- [ ] 1.4 Add method to clear scroll position
+- [ ] 1.5 Add flag to detect data-affecting operations (filter, sort, refresh)
+
+## 2. Setup RecyclerView Scroll Listener
+
+- [ ] 2.1 Create custom RecyclerView.OnScrollListener in MovieListFragment
+- [ ] 2.2 Implement onScrolled() to capture scroll position on each scroll event
+- [ ] 2.3 Attach scroll listener to RecyclerView in onViewCreated()
+- [ ] 2.4 Store scroll position in ViewModel via the listener
+
+## 3. Capture Position Before Navigation
+
+- [ ] 3.1 Hook into Navigation back press event handling
+- [ ] 3.2 Capture and save scroll position before navigate() call in details navigation
+- [ ] 3.3 Ensure position is saved before back navigation executes
+- [ ] 3.4 Test rapid navigation to ensure position is always captured
+
+## 4. Handle Filter and Sort Changes
+
+- [ ] 4.1 Add observer to filter state changes
+- [ ] 4.2 Clear scroll position when filter is applied
+- [ ] 4.3 Add observer to sort state changes
+- [ ] 4.4 Clear scroll position when sort order changes
+- [ ] 4.5 Implement pull-to-refresh callback to clear scroll position
+
+## 5. Restore Scroll Position
+
+- [ ] 5.1 Add observer to list data changes in MovieListFragment
+- [ ] 5.2 Extract scroll position from ViewModel when data is loaded
+- [ ] 5.3 Implement scroll restoration logic that runs after layout
+- [ ] 5.4 Use ViewTreeObserver.OnPreDrawListener or post() to delay restoration
+- [ ] 5.5 Apply scroll position via RecyclerView.smoothScrollToPosition()
+
+## 6. Edge Case Handling
+
+- [ ] 6.1 Implement position clamping (clamp to list.size - 1 if needed)
+- [ ] 6.2 Handle empty list scenario (skip restoration)
+- [ ] 6.3 Handle first-time launch (no stored position)
+- [ ] 6.4 Test configuration change during navigation
+- [ ] 6.5 Test configuration change during details view
+
+## 7. Integration with Remember-Selected-Movie
+
+- [ ] 7.1 Verify scroll position restoration preserves selected movie highlight
+- [ ] 7.2 Test that both features work together without conflict
+- [ ] 7.3 Ensure selected movie highlight is visible in restored scroll position
+- [ ] 7.4 Handle scenario where selected movie is outside scroll range
+
+## 8. Testing
+
+- [ ] 8.1 Write unit tests for scroll position capture/restore ViewModel logic
+- [ ] 8.2 Write instrumented test for scroll listener attachment
+- [ ] 8.3 Write instrumented test for navigation back behavior
+- [ ] 8.4 Test on different screen sizes and orientations
+- [ ] 8.5 Test with various list sizes (small, medium, large)
+- [ ] 8.6 Verify no memory leaks from scroll listener
+- [ ] 8.7 Performance test: measure scroll restoration time
+
+## 9. Code Review and Cleanup
+
+- [ ] 9.1 Review and document scroll position capture/restore logic
+- [ ] 9.2 Remove any debugging code or temporary implementations
+- [ ] 9.3 Ensure error handling for edge cases
+- [ ] 9.4 Add Javadoc/KDoc comments to key methods
+- [ ] 9.5 Perform final testing pass


### PR DESCRIPTION
Proposes a change to restore the movie list scroll position when users return from the details page, ensuring the previously viewed movie remains visible and highlighted.

## Change Summary
- **Feature**: restore-list-scroll-position
- **Problem**: List resets to top after returning from details, breaking UX
- **Solution**: Capture and restore scroll position using ViewModel state

## Artifacts
- [x] proposal.md - Problem statement and capabilities
- [x] design.md - Technical approach and decisions  
- [x] specs/list-scroll-position/spec.md - 7 requirements with 18 scenarios
- [x] tasks.md - 48 implementation tasks organized in 9 phases

Ready for review and implementation.