### PR TITLE
config(copilot): add config commit type to conventional commits guide

### DIFF
--- a/COPILOT.md
+++ b/COPILOT.md
@@ -230,6 +230,7 @@ Follow the **Conventional Commits** specification:
 - `chore`: Changes to build process or auxiliary tools
 - `perf`: Performance improvements
 - `ci`: CI/CD configuration changes
+- `config`: To reflect changes in the project's configuration
 
 **Examples**:
 ```


### PR DESCRIPTION
## Description
Update the COPILOT.md development guide to document the `config` commit type in the Conventional Commits specification. This type is used to reflect changes in the project's configuration.

## Type of Change
- [ ] 🎉 New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] ♻️ Code refactoring
- [ ] ✅ Test updates

## Changes Made
- Added `config` to the list of commit types in Conventional Commits section
- Documented that `config` type is used to reflect changes in the project's configuration

## Pre-Submission Checklist
- [x] Documentation updated appropriately
- [x] No sensitive data included